### PR TITLE
Switch to using a config file for app config and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ cd fedora-nightly-azure-image-validation
 
 ### Application Configuration
 
-Configuration parameters in `consume.py`:
+Configuration parameters in `azure.py`:
 
 ```python
 REGION = "westus3"  # Azure region for test execution
@@ -174,15 +174,13 @@ SUBSCRIPTION_ID = "your-azure-subscription-id"  # Your Azure subscription
 2. **Start the Message Consumer**:
    ```bash
    PYTHONPATH=/path/to/fedora-nightly-azure-image-validation \
-   fedora-messaging --conf my_config.toml \
-   consume --callback="consume:AzurePublishedConsumer"
+   fedora-messaging --conf my_config.toml consume
    ```
 
 3. **For Testing/Debugging** - Reconsume Specific Messages:
    ```bash
    PYTHONPATH=/path/to/fedora-nightly-azure-image-validation \
-   fedora-messaging --conf my_config.toml \
-   reconsume --callback="consume:AzurePublishedConsumer" "<message-id>"
+   fedora-messaging --conf my_config.toml reconsume "<message-id>"
    ```
 
 ### Environment Variables

--- a/fedora-messaging.toml.example
+++ b/fedora-messaging.toml.example
@@ -1,0 +1,90 @@
+# A sample configuration for fedora-messaging. This file is in the TOML format.
+amqp_url = "amqps://fedora:@rabbitmq.fedoraproject.org/%2Fpublic_pubsub"
+callback = "fedora_cloud_tests.azure:AzurePublishedConsumer"
+
+[tls]
+ca_cert = "/etc/fedora-messaging/cacert.pem"
+keyfile = "/etc/fedora-messaging/fedora-key.pem"
+certfile = "/etc/fedora-messaging/fedora-cert.pem"
+
+# Queue names *must* be in the normal UUID format: run "uuidgen" and use the
+# output as your queue name. If you don't define a queue here, the server will
+# generate a queue name for you. This queue will be non-durable, auto-deleted and
+# exclusive.
+# If your queue is not exclusive, anyone can connect and consume from it, causing
+# you to miss messages, so do not share your queue name. Any queues that are not
+# auto-deleted on disconnect are garbage-collected after approximately one hour.
+#
+# If you require a stronger guarantee about delivery, please talk to Fedora's
+# Infrastructure team.
+#
+# If you use the server-generated queue names, you can leave out the "queue"
+# parameter in the bindings definition.
+[[bindings]]
+# queue = "00000000-0000-0000-0000-000000000000"
+exchange = "amq.topic"
+routing_keys = ["org.fedoraproject.*.fedora_image_uploader.published.v1.azure.*"]
+
+[qos]
+prefetch_size = 0
+prefetch_count = 25
+
+
+[client_properties]
+app = "Fedora Cloud Tests"
+# TODO: Move to some Fedora-managed space
+app_url = "https://github.com/balakreddy/fedora-nightly-azure-image-validation"
+app_contacts_email = "cloud@lists.fedoraproject.org"
+
+# The Azure consumer namespaces its configuration under the "azure" key.
+[consumer_config.azure]
+# The region to use when creating test resources
+region = "westus3"
+# The Azure subscription ID for test resources
+subscription_id = "00000000-0000-0000-0000-000000000000"
+
+
+[log_config]
+version = 1
+disable_existing_loggers = true
+
+[log_config.formatters.simple]
+format = "%(asctime)s [%(name)s - %(levelname)s] - %(message)s"
+
+[log_config.handlers.console]
+class = "logging.StreamHandler"
+formatter = "simple"
+stream = "ext://sys.stdout"
+
+[log_config.handlers.file]
+class = "logging.FileHandler"
+formatter = "simple"
+filename = "consumer.log"
+
+[log_config.loggers.fedora_cloud_tests]
+level = "INFO"
+propagate = false
+handlers = ["console", "file"]
+
+[log_config.loggers.fedora_messaging]
+level = "INFO"
+propagate = false
+handlers = ["console"]
+
+# Twisted is the asynchronous framework that manages the TCP/TLS connection, as well
+# as the consumer event loop. When debugging you may want to lower this log level.
+[log_config.loggers.twisted]
+level = "INFO"
+propagate = false
+handlers = ["console"]
+
+# Pika is the underlying AMQP client library. When debugging you may want to
+# lower this log level.
+[log_config.loggers.pika]
+level = "WARNING"
+propagate = false
+handlers = ["console"]
+
+[log_config.root]
+level = "ERROR"
+handlers = ["console"]

--- a/fedora_cloud_tests/trigger_lisa.py
+++ b/fedora_cloud_tests/trigger_lisa.py
@@ -4,13 +4,15 @@ import asyncio
 import logging
 import subprocess
 
+_log = logging.getLogger(__name__)
+
 
 # pylint: disable=too-few-public-methods
 class LisaRunner:
     """Class to run LISA tests asynchronously"""
 
-    def __init__(self, logger=None):
-        self.logger = logger or logging.getLogger(__name__)
+    def __init__(self):
+        pass
 
     async def trigger_lisa(
         self, region, community_gallery_image, config):
@@ -32,25 +34,25 @@ class LisaRunner:
         """
         # Validate the input parameters
         if not region or not isinstance(region, str):
-            self.logger.error("Invalid region parameter: must be a non-empty string")
+            _log.error("Invalid region parameter: must be a non-empty string")
             return False
 
         if not community_gallery_image or not isinstance(community_gallery_image, str):
-            self.logger.error(
+            _log.error(
                 "Invalid community_gallery_image parameter: must be a non-empty string"
             )
             return False
 
         if not isinstance(config, dict):
-            self.logger.error("Invalid config parameter: must be a dictionary")
+            _log.error("Invalid config parameter: must be a dictionary")
             return False
 
         if not config.get("subscription"):
-            self.logger.error("Missing required parameter: subscription")
+            _log.error("Missing required parameter: subscription")
             return False
 
         if not config.get("private_key"):
-            self.logger.error("Missing required parameter: private_key")
+            _log.error("Missing required parameter: private_key")
             return False
 
         try:
@@ -73,37 +75,37 @@ class LisaRunner:
             log_path = config.get("log_path")
             if log_path:
                 command.extend(["-l", log_path])
-                self.logger.debug("Added log path: %s", log_path)
+                _log.debug("Added log path: %s", log_path)
             else:
-                self.logger.debug("No log path provided, using LISA default")
+                _log.debug("No log path provided, using LISA default")
 
             run_name = config.get("run_name")
             if run_name:
                 command.extend(["-i", run_name])
-                self.logger.debug("Added run name: %s", run_name)
+                _log.debug("Added run name: %s", run_name)
             else:
-                self.logger.debug("No run name provided, using LISA default")
+                _log.debug("No run name provided, using LISA default")
 
-            self.logger.info("Starting LISA test with command: %s", " ".join(command))
+            _log.info("Starting LISA test with command: %s", " ".join(command))
             process = await asyncio.create_subprocess_exec(
                 *command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             stdout, stderr = await process.communicate()
 
             if process.returncode == 0:
-                self.logger.info(
+                _log.info(
                     "LISA test completed successfully with output %s.",
                     stdout.decode(),
                 )
                 if stderr:
-                    self.logger.info("LISA test has warnings: %s", stderr.decode())
+                    _log.info("LISA test has warnings: %s", stderr.decode())
                 return True
-            self.logger.error("Triggering LISA tests failed %d", process.returncode)
+            _log.error("Triggering LISA tests failed %d", process.returncode)
             if stdout:
-                self.logger.error("Standard Output: %s", stdout.decode())
+                _log.error("Standard Output: %s", stdout.decode())
             if stderr:
-                self.logger.error("Standard Error: %s", stderr.decode())
+                _log.error("Standard Error: %s", stderr.decode())
             return False
         except Exception as e:  # pylint: disable=broad-except
-            self.logger.error("An error occurred while running the tests: %s", str(e))
+            _log.error("An error occurred while running the tests: %s", str(e))
             return False

--- a/tests/test_trigger_lisa.py
+++ b/tests/test_trigger_lisa.py
@@ -3,13 +3,13 @@
 import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
-from fedora_cloud_tests.trigger_lisa import LisaRunner
+from fedora_cloud_tests import trigger_lisa
 
 
 @pytest.fixture
 def runner():
     """Create a LisaRunner instance for testing."""
-    return LisaRunner()
+    return trigger_lisa.LisaRunner()
 
 
 @pytest.fixture
@@ -66,7 +66,7 @@ class TestLisaRunner:
             )
             mock_subproc_exec.return_value = mock_process
 
-            with patch.object(runner.logger, "info") as mock_logger_info:
+            with patch.object(trigger_lisa._log, "info") as mock_logger_info:
                 result = await runner.trigger_lisa(
                     region, community_gallery_image, config_params
                 )
@@ -88,7 +88,7 @@ class TestLisaRunner:
             )
             mock_subproc_exec.return_value = mock_process
 
-            with patch.object(runner.logger, "error") as mock_logger_error:
+            with patch.object(trigger_lisa._log, "error") as mock_logger_error:
                 result = await runner.trigger_lisa(
                     region, community_gallery_image, config_params
                 )
@@ -104,7 +104,7 @@ class TestLisaRunner:
         with patch(
             "asyncio.create_subprocess_exec", side_effect=Exception("Process failed")
         ):
-            with patch.object(runner.logger, "error") as mock_logger_error:
+            with patch.object(trigger_lisa._log, "error") as mock_logger_error:
                 result = await runner.trigger_lisa(
                     region, community_gallery_image, config_params
                 )
@@ -117,7 +117,7 @@ class TestLisaRunner:
     @pytest.mark.asyncio
     async def test_trigger_lisa_missing_region(self, runner, community_gallery_image, config_params):
         """Test validation failure when region is missing."""
-        with patch.object(runner.logger, "error") as mock_logger_error:
+        with patch.object(trigger_lisa._log, "error") as mock_logger_error:
             result = await runner.trigger_lisa(
                 "", community_gallery_image, config_params
             )
@@ -130,7 +130,7 @@ class TestLisaRunner:
     @pytest.mark.asyncio
     async def test_trigger_lisa_missing_community_gallery_image(self, runner, region, config_params):
         """Test validation failure when community_gallery_image is missing."""
-        with patch.object(runner.logger, "error") as mock_logger_error:
+        with patch.object(trigger_lisa._log, "error") as mock_logger_error:
             result = await runner.trigger_lisa(region, "", config_params)
 
             assert result is False
@@ -144,7 +144,7 @@ class TestLisaRunner:
         config_without_subscription = config_params.copy()
         del config_without_subscription["subscription"]
 
-        with patch.object(runner.logger, "error") as mock_logger_error:
+        with patch.object(trigger_lisa._log, "error") as mock_logger_error:
             result = await runner.trigger_lisa(
                 region, community_gallery_image, config_without_subscription
             )
@@ -160,7 +160,7 @@ class TestLisaRunner:
         config_without_private_key = config_params.copy()
         del config_without_private_key["private_key"]
 
-        with patch.object(runner.logger, "error") as mock_logger_error:
+        with patch.object(trigger_lisa._log, "error") as mock_logger_error:
             result = await runner.trigger_lisa(
                 region, community_gallery_image, config_without_private_key
             )
@@ -277,7 +277,7 @@ class TestLisaRunner:
     @pytest.mark.asyncio
     async def test_trigger_lisa_invalid_config_type(self, runner, region, community_gallery_image):
         """Test validation failure when config is not a dictionary."""
-        with patch.object(runner.logger, "error") as mock_logger_error:
+        with patch.object(trigger_lisa._log, "error") as mock_logger_error:
             result = await runner.trigger_lisa(
                 region, community_gallery_image, "not a dict"  # Invalid type
             )
@@ -286,9 +286,3 @@ class TestLisaRunner:
             mock_logger_error.assert_called_with(
                 "Invalid config parameter: must be a dictionary"
             )
-
-    def test_lisa_runner_init_without_logger(self):
-        """Test LisaRunner initialization without custom logger."""
-        runner = LisaRunner()
-        assert runner.logger is not None
-        assert runner.logger.name == "fedora_cloud_tests.trigger_lisa"


### PR DESCRIPTION
This switches the consumer to use the fedora-messaging configuration file for config values, including log configuration. It also moves the Azure consumer to an `azure` module since in the future we will run tests against all the clouds Fedora supports.

It also sets up an example configuration file which can be used to run the consumer with `fedora-messaging --conf
./fedora-messaging.toml.example consume`.